### PR TITLE
feat(With_Post_Remapping) add get_mock_event method

### DIFF
--- a/src/PHPUnit/Traits/With_Post_Remapping.php
+++ b/src/PHPUnit/Traits/With_Post_Remapping.php
@@ -16,6 +16,8 @@ trait With_Post_Remapping {
 
 	/**
 	 * An array containing the content dynamically generated from templates.
+	 *
+	 * @var array
 	 */
 	protected $dynamic_content = [];
 
@@ -182,7 +184,7 @@ trait With_Post_Remapping {
 			$contents = file_get_contents( $file );
 		}
 
-		$decoded  = json_decode( $contents, true );
+		$decoded = json_decode( $contents, true );
 
 		return (array) $decoded;
 	}
@@ -218,8 +220,8 @@ trait With_Post_Remapping {
 	 *
 	 * @since TBD
 	 *
-	 * @param           string $target The path, relative to the the plugin `tests/_data/remap` directory, to the static
-	 *                                 JSON file or JSON file template.
+	 * @param           string     $target The path, relative to the the plugin `tests/_data/remap` directory, to the static
+	 *                                     JSON file or JSON file template.
 	 * @param array|null $template_vars If specified the content of the specified JSON file target will be used as a
 	 *                                  template, its values filled to those specified in the template variables.
 	 *                                  Variables will be replaced to their `{{ <key> }}` counterpart in the template.


### PR DESCRIPTION
Add the `With_Post_Remapping::get_mock_event` method to creat and remap an event to a static data set.  
The basic use, in the context of a test case using the trait, is:

```php
// Create an event and remap it to the /events/single/1.json.
$this->get_mock_event( 'events/single/1.json' );
```

If the static JSON file contains placeholders like `{{ id }}`, then it can be used as a template:

```php
$this->get_mock_event( 'events/single/standard.template.json', [ 'id' => 'foo' ] );
```