### PR TITLE
fix(Vies/V2/HtmlPartialTestCase.php) set template vars globally

### DIFF
--- a/src/Products/WPBrowser/Views/V2/HtmlPartialTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/HtmlPartialTestCase.php
@@ -86,6 +86,8 @@ class HtmlPartialTestCase extends WPTestCase {
 	 * @return string The partial rendered HTML.
 	 */
 	protected function get_partial_html( array $context = [] ) {
+		$this->template->set_values( $context, false );
+
 		return $this->template->template( $this->partial_path, $context );
 	}
 }


### PR DESCRIPTION
When extracting the context in HTML Partial test case make sure to do it globally to allow nested templates to inherit it.