### PR TITLE
Feat - add format_sql function.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "autoload": {
         "psr-4": {
             "Tribe\\Test\\": "src"
-        }
+        },
+        "files": ["src/functions.php"]
     },
     "repositories": [
         {
@@ -30,7 +31,8 @@
     ],
     "require": {
 		"php": ">=7.0",
-        "lucatume/wp-browser": "^2.0"
+        "lucatume/wp-browser": "^2.0",
+        "nilportugues/sql-query-formatter": "^1.2"
     },
     "require-dev": {
         "wp-coding-standards/wpcs": "^2.1",

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Utility functions.
+ *
+ * @since TBD
+ *
+ * @package Tribe\Test
+ */
+
+namespace Tribe\Test;
+
+use NilPortugues\Sql\QueryFormatter\Formatter as Sql_Formatter;
+
+/**
+ * Formats a SQL string in a "pretty" format.
+ *
+ * @since TBD
+ *
+ * @param string $sql_string The SQL string to format.
+ *
+ * @return string The formatted SQL string.
+ *
+ * @uses \NilPortugues\Sql\QueryFormatter\Formatter::format()
+ */
+function format_sql( $sql_string ) {
+	static $formatter;
+	if ( null === $formatter ) {
+		$formatter = new Sql_Formatter();
+	}
+
+	return $formatter->format( $sql_string );
+}


### PR DESCRIPTION
This PR adds the `Tribe\Test\format_sql` function to format SQL strings to a pretty format.

The formatting is handled by the `nilportugues/sql-query-formatter` package.

So far I've used it to pretty print debug messages with SQL code on failures:
<img width="982" alt="Screenshot 2019-10-03 at 11 22 33" src="https://user-images.githubusercontent.com/2749650/66114983-36fcb480-e5d0-11e9-92c0-299fd662d5ab.png">
