### PR TITLE
Feat - add date-dependant template var check

### DIFF
--- a/src/PHPUnit/Traits/With_Post_Remapping.php
+++ b/src/PHPUnit/Traits/With_Post_Remapping.php
@@ -350,4 +350,44 @@ trait With_Post_Remapping {
 			? tribe_get_organizer_object( $remapped_id )
 			: get_post( $remapped_id );
 	}
+
+	/**
+	 * Inserts a post in the database with a direct query.
+	 *
+	 * This is useful to create real versions of mock posts.
+	 *
+	 * @since TBD
+	 *
+	 * @param \WP_Post $post The post object to insert.
+	 */
+	protected function wp_insert_post( \WP_Post $post ) {
+		global $wpdb;
+		$post_fields         = [
+			'ID',
+			'post_author',
+			'post_date',
+			'post_date_gmt',
+			'post_content',
+			'post_title',
+			'post_excerpt',
+			'post_status',
+			'comment_status',
+			'ping_status',
+			'post_password',
+			'post_name',
+			'to_ping',
+			'pinged',
+			'post_modified',
+			'post_modified_gmt',
+			'post_content_filtered',
+			'post_parent',
+			'guid',
+			'menu_order',
+			'post_type',
+			'post_mime_type',
+			'comment_count',
+		];
+		$array_intersect_key = array_intersect_key( (array) $post, array_combine( $post_fields, $post_fields ) );
+		$wpdb->insert( $wpdb->posts, $array_intersect_key );
+	}
 }

--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -182,7 +182,7 @@ class ViewTestCase extends TestCase {
 			$date_dependant,
 			sprintf(
 				"Date-dependent template vars found matching today date: all dates should be mocked!\n%s",
-				json_encode( array_keys( $date_dependant ), JSON_PRETTY_PRINT )
+				json_encode( $date_dependant, JSON_PRETTY_PRINT )
 			)
 		);
 


### PR DESCRIPTION
Ticket: http://central.tri.be/issues/135291

This PR adds a check on each View template vars, when rendered in the conetxt of tests, to make sure there are no dates that match today's date.
This makes it easier to spot faulty snapshots and the method provides a readable output:

```bash
1) Venue_ViewTest: Test_render_empty
 Test  tests/views_integration/Tribe/Events/Pro/Views/V2/Views/Venue_ViewTest.php:test_render_empty
Date-dependent template vars found matching today date: all dates should be mocked!
[
    "today": "2019-11-07 00:00:00",
    "now": "2019-11-07 12:43:59",
    "selected_start_datetime": "2019-11-07",
    "selected_start_date_mobile": "2019-11-07",
    "selected_end_datetime": "2019-11-07",
    "selected_end_date_mobile": "2019-11-07",
    "datepicker_date": "2019-11-07"
]
Failed asserting that an array is empty.
```

The PR also adds the `With_Post_Remapping::wp_insert_post` method to persist, with a direct database call, mock posts into the database if required.