### PR TITLE
fix(Views/V2/ViewTestCase.php) ignore post_(date|modified) in date mock checks

### DIFF
--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -174,7 +174,21 @@ class ViewTestCase extends TestCase {
 		$date_dependant = array_filter(
 			$template_vars,
 			function ( $v ) {
-				return false !== strpos( json_encode( $v ), $this->today_date );
+				// The pretty print will print each value on diff. lines.
+				$encoded = json_encode( $v, JSON_PRETTY_PRINT );
+
+				// Ignore the `post_date` and `post_modified` fields.
+				$encoded = implode(
+					PHP_EOL,
+					array_filter(
+						explode( PHP_EOL, $encoded ),
+						static function ( $line ) {
+							return ! preg_match( '/post_(date|modified)(_gmt)*/', $line );
+						}
+					)
+				);
+
+				return false !== strpos( $encoded, $this->today_date );
 			}
 		);
 


### PR DESCRIPTION
Ticket (partially related): https://central.tri.be/issues/136624

This PR udpates the code that, in the `ViewTestCase`, makes sure that all date(-ish) values
used in a test are mocked to exclude `post_date` and `post_modified` fields are ignored.

These fields are pre-set by WordPress when generating events w/ a factory and it does not
make sense to enforce them.