### PR TITLE
fix(ViewTestCase.php) refresh the global context before view tests

### DIFF
--- a/cs-ruleset.xml
+++ b/cs-ruleset.xml
@@ -5,4 +5,7 @@
         <exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
     </rule>
     <rule ref="WordPress-Docs"/>
+    <rule ref="Generic.Arrays.DisallowShortArraySyntax">
+        <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
+    </rule>
 </ruleset>

--- a/src/Mock/Builder/Event.php
+++ b/src/Mock/Builder/Event.php
@@ -192,7 +192,7 @@ class Event {
 		add_filter(
 			'tribe_is_recurring_event',
 			function ( $recurring, $post_id = null ) {
-				$post_id = $post_id ?: \Tribe__Main::post_id_helper( $post_id );
+				$post_id = $post_id ? $post_id : \Tribe__Main::post_id_helper( $post_id );
 
 				return (int) $post_id === $this->event->ID;
 			}
@@ -235,7 +235,7 @@ class Event {
 			$venue    = $this->get_mock_venue( $target, $template_vars );
 			$venue_id = $venue->ID;
 		} else {
-			$this->venue_factory = $this->venue_factory ?: new  Venue();
+			$this->venue_factory = $this->venue_factory ? $this->venue_factory : new  Venue();
 			$venue_id            = $this->venue_factory->create();
 		}
 
@@ -277,7 +277,7 @@ class Event {
 
 			$organizer_ids = array_map( $create, $template_vars_array );
 		} else {
-			$this->organizer_factory = $this->organizer_factory ?: new Organizer();
+			$this->organizer_factory = $this->organizer_factory ? $this->organizer_factory : new Organizer();
 
 			$create = function () {
 				return $this->organizer_factory->create();

--- a/src/PHPUnit/Traits/With_Post_Remapping.php
+++ b/src/PHPUnit/Traits/With_Post_Remapping.php
@@ -127,7 +127,7 @@ trait With_Post_Remapping {
 			$target                         = $hash;
 		}
 
-		$factory = $this->factory ?: static::factory();
+		$factory = $this->factory ? $this->factory : static::factory();
 		$post_id = $factory->post->create();
 		$remap   = $this->remap_posts( [ $post_id ], [ $target ] );
 

--- a/src/Products/WPBrowser/Views/V2/HtmlPartialTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/HtmlPartialTestCase.php
@@ -73,6 +73,7 @@ class HtmlPartialTestCase extends WPTestCase {
 		add_filter(
 			'wp_get_attachment_url',
 			static function ( $url ) use ( $home_url ) {
+				// phpcs:ignore
 				return str_replace( [ $home_url, date( 'Y/m' ) ], [ 'http://test.tri.be', '2018/08' ], $url );
 			}
 		);

--- a/src/Products/WPBrowser/Views/V2/HtmlTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/HtmlTestCase.php
@@ -75,6 +75,7 @@ abstract class HtmlTestCase extends TestCase {
 		add_filter(
 			'wp_get_attachment_url',
 			static function ( $url ) use ( $home_url ) {
+				// phpcs:ignore
 				return str_replace( [ $home_url, date( 'Y/m' ) ], [ 'http://test.tri.be', '2018/08' ], $url );
 			}
 		);

--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -54,6 +54,7 @@ class ViewTestCase extends TestCase {
 		// Start Function Mocker.
 		Test::setUp();
 
+		// phpcs:ignore
 		$this->today_date = date( 'Y-m-d' );
 
 		// Mock calls to the `date` function to return a fixed value when getting the current date.

--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -92,6 +92,9 @@ class ViewTestCase extends TestCase {
 
 		$this->date_dependent_template_vars = [];
 		add_filter( 'tribe_events_views_v2_view_template_vars', [ $this, 'collect_date_dependent_values' ] );
+
+		// Refresh the global Contex to start fresh on each test run.
+		tribe_context()->refresh();
 	}
 
 	/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/138218 

This PR updates the `ViewTestCase` parent test case to make sure the global Contenxt, the default one returned by the `tribe_events` function is refreshed before each View test.

The `Tribe__Context::refresh` method will clean the request cache that would create inter-dependencies between tests.