### PR TITLE
feat(Traits) add and use With_Context trait to handle context in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "wp-coding-standards/wpcs": "^2.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "wordpress/wordpress": "dev-master",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.0",
+        "codeception/codeception": "^3.0"
     },
     "scripts": {
         "code-sniff": "vendor/bin/phpcs --standard=./cs-ruleset.xml -s src",

--- a/src/PHPUnit/Traits/With_Post_Remapping.php
+++ b/src/PHPUnit/Traits/With_Post_Remapping.php
@@ -390,4 +390,28 @@ trait With_Post_Remapping {
 		$array_intersect_key = array_intersect_key( (array) $post, array_combine( $post_fields, $post_fields ) );
 		$wpdb->insert( $wpdb->posts, $array_intersect_key );
 	}
+
+	/**
+	 * Remaps a set of real post IDs to a set of mock/fake post IDs.
+	 *
+	 * This method is useful when real posts are required in the database, say to satisfy a query, but fake post and
+	 * post meta data is required for the purpose of snapshot testing.
+	 * In this instances create the real, test, posts using factories and, then, remap them to snapshot-ready mock posts
+	 * after this.
+	 *
+	 * @param array<int> $original_ids The set of original post IDs.
+	 * @param array<int> $mock_ids     The set of mock post IDs.
+	 *
+	 * @throws \InvalidArgumentException If the count of the two arrays does not match.
+	 */
+	protected function remap_post_ids( array $original_ids, array $mock_ids ) {
+		if ( count( $original_ids ) !== count( $mock_ids ) ) {
+			throw new \InvalidArgumentException( 'The number of elements in the two arrays must match.' );
+		}
+
+		foreach ( array_combine( $original_ids, $mock_ids ) as $from => $to ) {
+			wp_cache_set( $from, wp_cache_get( $to, 'posts' ), 'posts' );
+			wp_cache_set( $from, wp_cache_get( $to, 'post_meta' ), 'post_meta' );
+		}
+	}
 }

--- a/src/Products/Traits/With_Context.php
+++ b/src/Products/Traits/With_Context.php
@@ -52,7 +52,7 @@ trait With_Context {
 	 * @see   With_Context::reset_context For the method that will restore the context to an empty, new instance.
 	 */
 	protected function restore_context( Context $context = null ) {
-		$restore_to = $context ?: static::$context_backup;
+		$restore_to = $context ? $context : static::$context_backup;
 
 		if ( ! $restore_to instanceof Context ) {
 			// It might not have been backed up or not be a Context object.
@@ -68,14 +68,14 @@ trait With_Context {
 	 * "Current" is the keyword here: if the Context has been altered BEFORE this method runs, then the instance
 	 * of the Context that will be restored with the `restore_context` method will be this altered one.
 	 *
-	 * @param array<string,mixed> An array of alterations that will be applied to the context before it's backed up.
-	 *                            This allows setting the Context to a desired state that will be enforced on restore.
+	 * @param array<string,mixed> $alterations An array of alterations that will be applied to the context before it's
+	 *                                         backed up. This allows setting the Context to a desired state that will
+	 *                                         be enforced on restore.
 	 *
 	 * @since TBD
 	 */
 	protected function backup_context( array $alterations = null ) {
 		if ( tribe()->isBound( 'context' ) ) {
-			/** @var Context $context */
 			$context = tribe( 'context' );
 			if ( null !== $alterations ) {
 				$context = $context->alter( $alterations );

--- a/src/Products/Traits/With_Context.php
+++ b/src/Products/Traits/With_Context.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Provides methods to interact and manipulate the Context in test cases.
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Test\Products\Traits
+ */
+
+namespace Tribe\Test\Products\Traits;
+
+use Tribe__Context as Context;
+
+/**
+ * Trait With_Context
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Test\Products\Traits
+ */
+trait With_Context {
+
+	/**
+	 * Resets the global, shared instance of the Context to a new, blank, empty instance.
+	 *
+	 * @since TBD
+	 *
+	 * @see   With_Context::restore_context For the method that will restore the context to a previous state.
+	 * @see   With_Context::backup_context For the method to backup the global, shared instance of the Context.
+	 */
+	protected function reset_context() {
+		$this->restore_context( new Context() );
+	}
+
+	/**
+	 * Restores the global instance of the Context, the one returned from the bound `context` slug, to its initial
+	 * state and instance.
+	 *
+	 * During tests we might need to use the `Context::dangerously_set_global_context` method and that would alter the
+	 * global, shared, instance of the context for all tests.
+	 * This method provides a fix.
+	 * Differently from the `reset_context` method this method might be useful to restore the context to a previously
+	 * set state in place of a resetting it to a "blank" one.
+	 *
+	 * @since TBD
+	 *
+	 * @param Context|null $context The Context instance to reset the context to. This should be `null`, but room is
+	 *                              left for savvy developers to reset to an explicit context instance.
+	 *                              With great power comes great responsibility.
+	 *
+	 * @see   With_Context::backup_context For the method that sets up the Context instance that will be restored here.
+	 * @see   With_Context::reset_context For the method that will restore the context to an empty, new instance.
+	 */
+	protected function restore_context( Context $context = null ) {
+		$restore_to = $context ?: static::$context_backup;
+
+		if ( ! $restore_to instanceof Context ) {
+			// It might not have been backed up or not be a Context object.
+			return;
+		}
+
+		tribe_singleton( 'context', $restore_to );
+	}
+
+	/**
+	 * Backs up the current, global, shared instance of the Context to restore it later.
+	 *
+	 * "Current" is the keyword here: if the Context has been altered BEFORE this method runs, then the instance
+	 * of the Context that will be restored with the `restore_context` method will be this altered one.
+	 *
+	 * @since TBD
+	 */
+	protected function backup_context() {
+		if ( tribe()->isBound( 'context' ) ) {
+			static::$context_backup = tribe( 'context' );
+		}
+	}
+}

--- a/src/Products/Traits/With_Context.php
+++ b/src/Products/Traits/With_Context.php
@@ -68,11 +68,30 @@ trait With_Context {
 	 * "Current" is the keyword here: if the Context has been altered BEFORE this method runs, then the instance
 	 * of the Context that will be restored with the `restore_context` method will be this altered one.
 	 *
+	 * @param array<string,mixed> An array of alterations that will be applied to the context before it's backed up.
+	 *                            This allows setting the Context to a desired state that will be enforced on restore.
+	 *
 	 * @since TBD
 	 */
-	protected function backup_context() {
+	protected function backup_context( array $alterations = null ) {
 		if ( tribe()->isBound( 'context' ) ) {
-			static::$context_backup = tribe( 'context' );
+			/** @var Context $context */
+			$context = tribe( 'context' );
+			if ( null !== $alterations ) {
+				$context = $context->alter( $alterations );
+			}
+			static::$context_backup = $context;
 		}
+	}
+
+	/**
+	 * Checks whether the Context is backed up or not.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the Context is backed up or not.
+	 */
+	protected function context_backed_up() {
+		return static::$context_backup instanceof Context;
 	}
 }

--- a/src/Products/Traits/With_Context.php
+++ b/src/Products/Traits/With_Context.php
@@ -21,6 +21,14 @@ use Tribe__Context as Context;
 trait With_Context {
 
 	/**
+	 * A backup of the context in its initial state, taken at the start of the test case `setUp` method.
+	 * This is static to "snapshot" the context once, when the first test case of this type runs.
+	 *
+	 * @var Context
+	 */
+	protected static $context_backup;
+
+	/**
 	 * Resets the global, shared instance of the Context to a new, blank, empty instance.
 	 *
 	 * @since TBD

--- a/src/Products/WPBrowser/Views/V2/TestCase.php
+++ b/src/Products/WPBrowser/Views/V2/TestCase.php
@@ -16,6 +16,7 @@ use Tribe\Events\Test\Factories\Event;
 use Tribe\Events\Test\Factories\Organizer;
 use Tribe\Events\Test\Factories\Venue;
 use Tribe\Events\Views\V2\View_Interface;
+use Tribe\Test\Products\Traits\With_Context;
 use Tribe__Context as Context;
 
 /**
@@ -26,6 +27,7 @@ use Tribe__Context as Context;
 abstract class TestCase extends WPTestCase {
 
 	use MatchesSnapshots;
+	use With_Context;
 
 	/**
 	 * The current Context Mocker instance.
@@ -119,6 +121,21 @@ abstract class TestCase extends WPTestCase {
 		static::factory()->event     = new Event();
 		static::factory()->venue     = new Venue();
 		static::factory()->organizer = new Organizer();
+
+		// Ensure earliest and latest date, related to the creation of events, are reset.
+		tribe_update_option( 'earliest_date', '' );
+		tribe_update_option( 'latest_date', '' );
+
+		// Backup the context if not already done.
+		if ( ! $this->context_backed_up() ) {
+			$this->backup_context([
+				'latest_event_date' => null,
+				'earliest_event_date' => null,
+			]);
+		}
+
+		// Restore the context to its initial state.
+		$this->restore_context();
 	}
 
 	/**

--- a/src/Products/WPBrowser/Views/V2/TestCase.php
+++ b/src/Products/WPBrowser/Views/V2/TestCase.php
@@ -128,10 +128,12 @@ abstract class TestCase extends WPTestCase {
 
 		// Backup the context if not already done.
 		if ( ! $this->context_backed_up() ) {
-			$this->backup_context([
-				'latest_event_date' => null,
-				'earliest_event_date' => null,
-			]);
+			$this->backup_context(
+				[
+					'latest_event_date'   => null,
+					'earliest_event_date' => null,
+				]
+			);
 		}
 
 		// Restore the context to its initial state.

--- a/src/Products/WPBrowser/Views/V2/TestCase.php
+++ b/src/Products/WPBrowser/Views/V2/TestCase.php
@@ -125,19 +125,6 @@ abstract class TestCase extends WPTestCase {
 		// Ensure earliest and latest date, related to the creation of events, are reset.
 		tribe_update_option( 'earliest_date', '' );
 		tribe_update_option( 'latest_date', '' );
-
-		// Backup the context if not already done.
-		if ( ! $this->context_backed_up() ) {
-			$this->backup_context(
-				[
-					'latest_event_date'   => null,
-					'earliest_event_date' => null,
-				]
-			);
-		}
-
-		// Restore the context to its initial state.
-		$this->restore_context();
 	}
 
 	/**

--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -49,14 +49,6 @@ class ViewTestCase extends TestCase {
 	protected $today_date;
 
 	/**
-	 * A backup of the context in its initial state, taken at the start of the test case `setUp` method.
-	 * This is static to "snapshot" the context once, when the first test case of this type runs.
-	 *
-	 * @var Context
-	 */
-	protected static $context_backup;
-
-	/**
 	 * Sets up the View test context mocking some commonly used functions and setting up the code to filter some time,
 	 * or date, dependant values to keep the snapshots consistent across time.
 	 */
@@ -109,23 +101,6 @@ class ViewTestCase extends TestCase {
 		// Ensure the before and after event HTML is reset.
 		tribe_update_option( Advanced_Display::$key_before_events_html, '' );
 		tribe_update_option( Advanced_Display::$key_after_events_html, '' );
-
-		// Ensure earliest and latest date, related to the creation of events, are reset.
-		tribe_update_option( 'earliest_date', '' );
-		tribe_update_option( 'latest_date', '' );
-
-		// Backup the context if not already done.
-		if ( ! $this->context_backed_up() ) {
-			$this->backup_context(
-				[
-					'latest_event_date'   => null,
-					'earliest_event_date' => null,
-				]
-			);
-		}
-
-		// Restore the context to its initial state.
-		$this->restore_context();
 	}
 
 	/**

--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -116,10 +116,12 @@ class ViewTestCase extends TestCase {
 
 		// Backup the context if not already done.
 		if ( ! $this->context_backed_up() ) {
-			$this->backup_context([
-				'latest_event_date' => null,
-				'earliest_event_date' => null,
-			]);
+			$this->backup_context(
+				[
+					'latest_event_date'   => null,
+					'earliest_event_date' => null,
+				]
+			);
 		}
 
 		// Restore the context to its initial state.

--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -97,6 +97,12 @@ class ViewTestCase extends TestCase {
 		$this->date_dependent_template_vars = [];
 		add_filter( 'tribe_events_views_v2_view_template_vars', [ $this, 'collect_date_dependent_values' ] );
 
+		/*
+		 * During tests events created by diff. tests might have the same ID: this will apply date details settings
+		 * previously cached to new events. This reset will ensure that's not the case.
+		 */
+		tribe_set_var( 'tribe_events_event_schedule_details', [] );
+
 		$this->reset_before_after_html_data();
 
 	}

--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -10,7 +10,10 @@ namespace Tribe\Test\Products\WPBrowser\Views\V2;
 
 use tad\FunctionMocker\FunctionMocker as Test;
 use Tribe\Test\PHPUnit\Traits\With_Post_Remapping;
+use Tribe\Test\Products\Traits\With_Context;
 use Tribe\Test\Products\Traits\With_Event_Data_Fetching;
+use Tribe\Test\Products\Traits\With_View_Context;
+use Tribe__Context as Context;
 
 /**
  * Class ViewTestCase
@@ -21,6 +24,7 @@ class ViewTestCase extends TestCase {
 
 	use With_Post_Remapping;
 	use With_Event_Data_Fetching;
+	use With_Context;
 
 	/**
 	 * In the `reset_post_dates` methods all date-related post fields will be set to this value.
@@ -45,14 +49,27 @@ class ViewTestCase extends TestCase {
 	protected $today_date;
 
 	/**
+	 * A backup of the context in its initial state, taken at the start of the test case `setUp` method.
+	 * This is static to "snapshot" the context once, when the first test case of this type runs.
+	 *
+	 * @var Context
+	 */
+	protected static $context_backup;
+
+	/**
 	 * Sets up the View test context mocking some commonly used functions and setting up the code to filter some time,
 	 * or date, dependant values to keep the snapshots consistent across time.
 	 */
 	public function setUp() {
 		parent::setUp();
 
+		$this->reset_context();
+
 		// Start Function Mocker.
 		Test::setUp();
+
+		// Restore the context to its initial state.
+		$this->reset_context();
 
 		// phpcs:ignore
 		$this->today_date = date( 'Y-m-d' );

--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -215,6 +215,9 @@ class ViewTestCase extends TestCase {
 	 *
 	 * The data is, normally, printed once per request, but this works against tests that are, from WordPress
 	 * perspective one long, single, request.
+	 *
+	 * @throws \RuntimeException If there's a problem reflecting on The Events Calendar Main class or setting the
+	 *                           property value.
 	 */
 	protected function reset_before_after_html_data() {
 		// Let's start by ensuring we're not adding any value to the before/after HTML using the option.
@@ -234,11 +237,20 @@ class ViewTestCase extends TestCase {
 			try {
 				$reflection_property = new \ReflectionProperty( $main, 'show_data_wrapper' );
 				$reflection_property->setAccessible( true );
-				$reflection_property->setValue( $main, [ 'before' => true, 'after' => true ] );
+				$reflection_property->setValue(
+					$main,
+					[
+						'before' => true,
+						'after'  => true,
+					]
+				);
 				$reflection_property->setAccessible( false );
 			} catch ( \ReflectionException $e ) {
-				$message = 'Error while trying to reset Tribe__Events__Main::show_data_wrapper property ' .
-				           'in ViewTestCase: ' . $e->getMessage();
+				$message = sprintf(
+					'Error while trying to reset % property in ViewTestCase: %s',
+					'Tribe__Events__Main::show_data_wrapper',
+					$e->getMessage()
+				);
 				throw new \RuntimeException( $message );
 			}
 		}

--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -9,10 +9,10 @@
 namespace Tribe\Test\Products\WPBrowser\Views\V2;
 
 use tad\FunctionMocker\FunctionMocker as Test;
+use Tribe\Events\Views\V2\Template\Settings\Advanced_Display;
 use Tribe\Test\PHPUnit\Traits\With_Post_Remapping;
 use Tribe\Test\Products\Traits\With_Context;
 use Tribe\Test\Products\Traits\With_Event_Data_Fetching;
-use Tribe\Test\Products\Traits\With_View_Context;
 use Tribe__Context as Context;
 
 /**
@@ -63,13 +63,8 @@ class ViewTestCase extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->reset_context();
-
 		// Start Function Mocker.
 		Test::setUp();
-
-		// Restore the context to its initial state.
-		$this->reset_context();
 
 		// phpcs:ignore
 		$this->today_date = date( 'Y-m-d' );
@@ -111,8 +106,24 @@ class ViewTestCase extends TestCase {
 		$this->date_dependent_template_vars = [];
 		add_filter( 'tribe_events_views_v2_view_template_vars', [ $this, 'collect_date_dependent_values' ] );
 
-		// Refresh the global Contex to start fresh on each test run.
-		tribe_context()->refresh();
+		// Ensure the before and after event HTML is reset.
+		tribe_update_option( Advanced_Display::$key_before_events_html, '' );
+		tribe_update_option( Advanced_Display::$key_after_events_html, '' );
+
+		// Ensure earliest and latest date, related to the creation of events, are reset.
+		tribe_update_option( 'earliest_date', '' );
+		tribe_update_option( 'latest_date', '' );
+
+		// Backup the context if not already done.
+		if ( ! $this->context_backed_up() ) {
+			$this->backup_context([
+				'latest_event_date' => null,
+				'earliest_event_date' => null,
+			]);
+		}
+
+		// Restore the context to its initial state.
+		$this->restore_context();
 	}
 
 	/**

--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -247,7 +247,7 @@ class ViewTestCase extends TestCase {
 				$reflection_property->setAccessible( false );
 			} catch ( \ReflectionException $e ) {
 				$message = sprintf(
-					'Error while trying to reset % property in ViewTestCase: %s',
+					'Error while trying to reset %s property in ViewTestCase: %s',
 					'Tribe__Events__Main::show_data_wrapper',
 					$e->getMessage()
 				);


### PR DESCRIPTION
While working on TEC views tests I've found out we had a number of test snapshots inter-depending one
on the other that would make snapshots depends on the number and sequence of the running tests.

The `With_Context` trait provides method to restore, or reset, the shared, global, Context instance
to a known or desired state before tests.