### PR TITLE
Add the With_Caches_Reset trait

### DIFF
--- a/src/Products/Traits/With_Caches_Reset.php
+++ b/src/Products/Traits/With_Caches_Reset.php
@@ -20,7 +20,7 @@ trait With_Caches_Reset {
 	/**
 	 * Flushes all the caches used by our plugins.
 	 *
-	 * Due to the eterogenous nature of our caching methods, the method contains a curated list of caching locations,
+	 * Due to the heterogenous nature of our caching methods, the method contains a curated list of caching locations,
 	 * methodologies and applications.
 	 */
 	protected function flush_all_caches() {

--- a/src/Products/Traits/With_Caches_Reset.php
+++ b/src/Products/Traits/With_Caches_Reset.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Provides methods to reset all caches that might alter a test execution.
+ *
+ * @package Tribe\Test\Products\Traits
+ */
+
+namespace Tribe\Test\Products\Traits;
+
+use Tribe\Events\Views\V2\Template\Settings\Advanced_Display;
+use Tribe__Context as Context;
+
+/**
+ * Trait With_Caches_Reset
+ *
+ * @package Tribe\Test\Products\Traits
+ */
+trait With_Caches_Reset {
+
+	/**
+	 * Flushes all the caches used by our plugins.
+	 *
+	 * Due to the eterogenous nature of our caching methods, the method contains a curated list of caching locations,
+	 * methodologies and applications.
+	 */
+	protected function flush_all_caches() {
+		// Ensure earliest and latest date, related to the creation of events, are reset.
+		tribe_update_option( 'earliest_date', '' );
+		tribe_update_option( 'latest_date', '' );
+
+		// Let's make sure there are no left-over events between tests.
+		tribe_events()->delete();
+
+		/*
+		 * During tests events created by diff. tests might have the same ID: this will apply date details settings
+		 * previously cached to new events. This reset will ensure that's not the case.
+		 */
+		tribe_set_var( 'tribe_events_event_schedule_details', [] );
+		tribe_set_var( 'tribe_get_start_date', [] );
+		tribe_set_var( 'tribe_get_end_date', [] );
+		tribe_set_var( 'tribe_events_get_the_excerpt', [] );
+
+		// Ensure cached URLs are cleaned.
+		tribe( 'events.rewrite' )->reset_caches();
+		tribe( 'events.rewrite' )->setup();
+
+		// Reset the JSON-LD cached data.
+		tribe_cache()['json-ld-data'] = [];
+
+		$this->reset_before_after_html_data();
+	}
+
+	/**
+	 * This method ensures that before/after HTML data is correctly printed for each test.
+	 *
+	 * The data is, normally, printed once per request, but this works against tests that are, from WordPress
+	 * perspective one long, single, request.
+	 *
+	 * @throws \RuntimeException If there's a problem reflecting on The Events Calendar Main class or setting the
+	 *                           property value.
+	 */
+	protected function reset_before_after_html_data() {
+		// Let's start by ensuring we're not adding any value to the before/after HTML using the option.
+		tribe_update_option( Advanced_Display::$key_before_events_html, '' );
+		tribe_update_option( Advanced_Display::$key_after_events_html, '' );
+
+		/*
+		 * The Events Calendar `Main::(before|after)_html_data_wrapper` will use a private property to know if it should
+		 * print the before and after data or not. This means the data is printed on the first test that will trigger
+		 * it and won't be printed for any later test. This creates differences in snapshots when generated alone (they
+		 * will have the before/after data) or when generated in the context of a whole suite run. Since the before
+		 * and after HTML is indeed part of the code we want to test in snapshots, here we use reflection to reset the
+		 * (private) property so that the before/after HTML data will be printed on each test.
+		 */
+		$main = tribe( 'tec.main' );
+		if ( property_exists( $main, 'show_data_wrapper' ) ) {
+			try {
+				$reflection_property = new \ReflectionProperty( $main, 'show_data_wrapper' );
+				$reflection_property->setAccessible( true );
+				$reflection_property->setValue(
+					$main,
+					[
+						'before' => true,
+						'after'  => true,
+					]
+				);
+				$reflection_property->setAccessible( false );
+			} catch ( \ReflectionException $e ) {
+				$message = sprintf(
+					'Error while trying to reset %s property in ViewTestCase: %s',
+					'Tribe__Events__Main::show_data_wrapper',
+					$e->getMessage()
+				);
+				throw new \RuntimeException( $message );
+			}
+		}
+	}
+}

--- a/src/Products/WPBrowser/Views/V2/HtmlPartialTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/HtmlPartialTestCase.php
@@ -13,6 +13,8 @@ use Spatie\Snapshots\MatchesSnapshots;
 use Tribe\Events\Views\V2\Template;
 use Tribe\Events\Views\V2\View;
 use Tribe\Events\Views\V2\Views\Reflector_View;
+use Tribe\Test\Products\Traits\With_Caches_Reset;
+use Tribe\Test\Products\Traits\With_Context;
 
 /**
  * Class HtmlPartialTestCase
@@ -21,6 +23,8 @@ use Tribe\Events\Views\V2\Views\Reflector_View;
  */
 class HtmlPartialTestCase extends WPTestCase {
 	use MatchesSnapshots;
+	use With_Caches_Reset;
+	use With_Context;
 
 	/**
 	 * The path, relative to the Views v2 views root folder, to the partial.
@@ -81,6 +85,17 @@ class HtmlPartialTestCase extends WPTestCase {
 				return str_replace( [ $home_url, date( 'Y/m' ) ], [ 'http://test.tri.be', '2018/08' ], $url );
 			}
 		);
+
+		$this->backup_context();
+		$this->flush_all_caches();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function tearDown() {
+		$this->restore_context();
+		parent::tearDown();
 	}
 
 	/**

--- a/src/Products/WPBrowser/Views/V2/HtmlTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/HtmlTestCase.php
@@ -13,6 +13,7 @@ use DOMWrap\Document;
 use Tribe\Events\Views\V2\Template;
 use Tribe\Events\Views\V2\View;
 use Tribe\Events\Views\V2\View_Interface;
+use Tribe\Test\Products\Traits\With_Caches_Reset;
 
 /**
  * Class TestCase
@@ -20,6 +21,9 @@ use Tribe\Events\Views\V2\View_Interface;
  * @package Tribe\Test\Products\WPBrowser\Views\V2;
  */
 abstract class HtmlTestCase extends TestCase {
+	use With_Caches_Reset;
+	use With_Context;
+
 	/**
 	 * Store the views loader
 	 *
@@ -83,6 +87,17 @@ abstract class HtmlTestCase extends TestCase {
 				return str_replace( [ $home_url, date( 'Y/m' ) ], [ 'http://test.tri.be', '2018/08' ], $url );
 			}
 		);
+
+		$this->backup_context();
+		$this->flush_all_caches();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function tearDown() {
+		$this->restore_context();
+		parent::tearDown();
 	}
 
 	/**

--- a/src/Products/WPBrowser/Views/V2/ViewTestCase.php
+++ b/src/Products/WPBrowser/Views/V2/ViewTestCase.php
@@ -11,6 +11,7 @@ namespace Tribe\Test\Products\WPBrowser\Views\V2;
 use tad\FunctionMocker\FunctionMocker as Test;
 use Tribe\Events\Views\V2\Template\Settings\Advanced_Display;
 use Tribe\Test\PHPUnit\Traits\With_Post_Remapping;
+use Tribe\Test\Products\Traits\With_Caches_Reset;
 use Tribe\Test\Products\Traits\With_Context;
 use Tribe\Test\Products\Traits\With_Event_Data_Fetching;
 
@@ -24,6 +25,7 @@ class ViewTestCase extends TestCase {
 	use With_Post_Remapping;
 	use With_Event_Data_Fetching;
 	use With_Context;
+	use With_Caches_Reset;
 
 	/**
 	 * In the `reset_post_dates` methods all date-related post fields will be set to this value.
@@ -96,24 +98,6 @@ class ViewTestCase extends TestCase {
 
 		$this->date_dependent_template_vars = [];
 		add_filter( 'tribe_events_views_v2_view_template_vars', [ $this, 'collect_date_dependent_values' ] );
-
-		/*
-		 * During tests events created by diff. tests might have the same ID: this will apply date details settings
-		 * previously cached to new events. This reset will ensure that's not the case.
-		 */
-		tribe_set_var( 'tribe_events_event_schedule_details', [] );
-		tribe_set_var( 'tribe_get_start_date', [] );
-		tribe_set_var( 'tribe_get_end_date', [] );
-		tribe_set_var( 'tribe_events_get_the_excerpt', [] );
-
-		// Ensure cached URLs are cleaned.
-		tribe( 'events.rewrite' )->reset_caches();
-		tribe( 'events.rewrite' )->setup();
-
-		// Reset the JSON-LD cached data.
-		tribe_cache()['json-ld-data'] = [];
-
-		$this->reset_before_after_html_data();
 	}
 
 	/**
@@ -223,51 +207,5 @@ class ViewTestCase extends TestCase {
 		);
 
 		return $template_vars;
-	}
-
-	/**
-	 * This method ensures that before/after HTML data is correctly printed for each test.
-	 *
-	 * The data is, normally, printed once per request, but this works against tests that are, from WordPress
-	 * perspective one long, single, request.
-	 *
-	 * @throws \RuntimeException If there's a problem reflecting on The Events Calendar Main class or setting the
-	 *                           property value.
-	 */
-	protected function reset_before_after_html_data() {
-		// Let's start by ensuring we're not adding any value to the before/after HTML using the option.
-		tribe_update_option( Advanced_Display::$key_before_events_html, '' );
-		tribe_update_option( Advanced_Display::$key_after_events_html, '' );
-
-		/*
-		 * The Events Calendar `Main::(before|after)_html_data_wrapper` will use a private property to know if it should
-		 * print the before and after data or not. This means the data is printed on the first test that will trigger
-		 * it and won't be printed for any later test. This creates differences in snapshots when generated alone (they
-		 * will have the before/after data) or when generated in the context of a whole suite run. Since the before
-		 * and after HTML is indeed part of the code we want to test in snapshots, here we use reflection to reset the
-		 * (private) property so that the before/after HTML data will be printed on each test.
-		 */
-		$main = tribe( 'tec.main' );
-		if ( property_exists( $main, 'show_data_wrapper' ) ) {
-			try {
-				$reflection_property = new \ReflectionProperty( $main, 'show_data_wrapper' );
-				$reflection_property->setAccessible( true );
-				$reflection_property->setValue(
-					$main,
-					[
-						'before' => true,
-						'after'  => true,
-					]
-				);
-				$reflection_property->setAccessible( false );
-			} catch ( \ReflectionException $e ) {
-				$message = sprintf(
-					'Error while trying to reset %s property in ViewTestCase: %s',
-					'Tribe__Events__Main::show_data_wrapper',
-					$e->getMessage()
-				);
-				throw new \RuntimeException( $message );
-			}
-		}
 	}
 }


### PR DESCRIPTION
While working on Views V2 I've noticed we were not completely cleaning up the context between tests.
This is due to more, different, ways we cache in our code.

This PR does two main things:

1. Add the `With_Caches_Reset` trait and move in it all the different cache invalidation methods we had scattered in our test cases.
2. Use the method in any test case, e.g. HTML partial tests, that actually needs it but it's not handling caching in any way.