### PR TITLE
Add the With_Tribe_Service_Mocks trait

### DIFF
--- a/docs/PHPUnit/Traits/With_Tribe_Service_Mocks.md
+++ b/docs/PHPUnit/Traits/With_Tribe_Service_Mocks.md
@@ -1,0 +1,72 @@
+# With_Tribe_Service_Mocks Trait
+
+Safely replace services in the `tribe()` service locators and restore them in tests.
+
+## What is this for?
+
+In most of our code we use a `tribe( $service )` function that is, in fact, an implementation of the Service Locator pattern.  
+
+While convenient and easy to use this might prove challenging to test; this trait purpose is to ease the pain of testing code that relies on the service locator and to do so without side-effects (e.g. altering the service locator permanently).
+
+## Example
+
+In one of our plugins we have this code:
+
+```php
+<?php
+tribe_register( 'service.one', new Service_One() );
+tribe_singleton( Service_Two::class, Service_Two::class );
+tribe_singleton( 'service.three', static function(){
+    return new Service_Three;
+} );
+```
+
+All the bindings listed above are legitimate and working, but each, in its own way, would pose a challenge in tests.  
+Without indulging in the service locator implementation details, the first one is a singleton binding in disguise, the second is an identity singleton, the third is a pretty Dependency Injection late instantiation implementation.  
+
+All those can be safely mocked in tests using the trait:
+
+```php
+<?php
+use Tribe\Test\PHPUnit\Traits\With_Tribe_Service_Mocks;
+
+class Class_Depending_On_Service_Locator{
+
+    public function go(){
+        return tribe( 'service.one' )->should_load()
+            && tribe( Service_Two::class )->is_ok()
+            && tribe('service.three')->all_works();
+    }
+
+}
+
+
+class SomeTest extends \Codeception\TestCase\WPTestCase
+{
+	use With_Tribe_Service_Mocks;
+	public function test_code_depending_on_service_locator() {
+        // Build the mocks using Codeception Stubs.
+		$mock_service_one = $this->makeEmpty( Service_One::class,[
+			'should_load' => false,
+		] );
+		$mock_service_two = $this->makeEmpty( Service_Two::class,[
+			'is_ok' => true,
+		] );
+		$mock_service_three = $this->makeEmpty( Service_Three::class,[
+			'all_works' => true,
+		] );
+
+		$replacement_map=[
+            'service.one'      => $mock_service_one,
+            Service_Two::class => $mock_service_two,
+            'service.three'    => $mock_service_three,
+        ];
+
+        $this->replacing_tribe_services( $replacement_map, function () {
+            $instance = new Class_Depending_On_Service_Locator();
+			$this->assertFalse( $instance->go() );
+		} );
+	}
+}
+
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,3 +26,4 @@ Here's a list of what's included in the library.
     * Traits
         * [With_Post_Remapping](PHPUnit/Traits/With_Post_Remapping.md)
         * [With_Filter_Manipulation](PHPUnit/Traits/With_Filter_Manipulation.md)
+        * [With_Tribe_Service_Mocks](PHPUnit/Traits/With_Tribe_Service_Mocks.md)

--- a/src/PHPUnit/Traits/With_Tribe_Service_Mocks.php
+++ b/src/PHPUnit/Traits/With_Tribe_Service_Mocks.php
@@ -66,9 +66,6 @@ trait With_Tribe_Service_Mocks {
 		// Run the method, the specified services will be replaced.
 		try {
 			$do();
-		} catch ( \Exception $e ) {
-			// Then throw.
-			throw $e;
 		} finally {
 			// Restore the service locator original instance.
 			setPrivateProperties( tribe(), [ 'instance' => $locator_instance ] );

--- a/src/PHPUnit/Traits/With_Tribe_Service_Mocks.php
+++ b/src/PHPUnit/Traits/With_Tribe_Service_Mocks.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Provides methods to safely mock and restore services handled by the `tribe()` service locator.
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Test\PHPUnit\Traits
+ */
+
+namespace Tribe\Test\PHPUnit\Traits;
+
+use function tad\WPBrowser\readPrivateProperty;
+use function tad\WPBrowser\setPrivateProperties;
+
+/**
+ * Trait With_Tribe_Service_Mocks
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Test\PHPUnit\Traits
+ */
+trait With_Tribe_Service_Mocks {
+
+	/**
+	 * Runs a callback replacing a `tribe()` service with a mock instance.
+	 *
+	 * To backup the service locator, the singleton instance of the `Tribe__Container` class, the method will use
+	 * Reflection.
+	 * This is the only way we can avoid eager instantiation of services that might have side effects and correct
+	 * handling of Closure implementations.
+	 * The original service locator instance is restored after the test ran.
+	 *
+	 * @since  TBD
+	 *
+	 * @param array<string,mixed> $replacement_map The map defining the replacement for each service.
+	 * @param callable            $do              The callback to call in the context of the altered service locator.
+	 *
+	 * @throws \ReflectionException If there's an issue reflecting on the service locator instance.
+	 *
+	 * @example
+	 *         ```php
+	 *         $mock = $this->makeEmpty( Some_Service::class, [ 'some_method' => 'foo' ] );
+	 *         $this->replacing_tribe_service( [ 'service.slug' => $mock ], function() {
+	 *              $this->assertEquals( 'foo', tribe( 'service.slug' )->some_method() );
+	 *         } );
+	 *         ```
+	 */
+	protected function replacing_tribe_services( array $replacement_map, callable $do ) {
+		// Get the current singleton instance of the service locator.
+		$locator_instance = readPrivateProperty( tribe(), 'instance' );
+
+		// Use Reflection to get hold of the singleton service locator instance.
+		$replacement_locator = clone $locator_instance;
+
+		foreach ( $replacement_map as $service => $replacement ) {
+			// Inject the replacement in the cloned service locator.
+			$replacement_locator->singleton( $service, $replacement );
+		}
+
+		// Replace the service locator instance w/ a shallow clone.
+		setPrivateProperties( tribe(), [ 'instance' => $replacement_locator ] );
+
+		// Register the replacement as a singleton.
+		tribe_singleton( $service, $replacement );
+
+		// Run the method, the specified services will be replaced.
+		try {
+			$do();
+		} catch ( \Exception $e ) {
+			// Then throw.
+			throw $e;
+		} finally {
+			// Restore the service locator original instance.
+			setPrivateProperties( tribe(), [ 'instance' => $locator_instance ] );
+		}
+	}
+}


### PR DESCRIPTION
This PR adds the `Traits\With_Tribe_Service_Mocks` trait to allow easy, and safe, replacement of the services managed by the `tribe()` service locator in tests.

I've updated the readme for traits to provide a usage example.