### PR TITLE
Reset request URI between tests

### DIFF
--- a/src/Products/WPBrowser/Views/V2/TestCase.php
+++ b/src/Products/WPBrowser/Views/V2/TestCase.php
@@ -103,6 +103,9 @@ abstract class TestCase extends WPTestCase {
 		static::factory()->organizer = new Organizer();
 
 		$this->flush_all_caches();
+
+		// Let's restore this value to avoid hijacking all Views.
+		$_SERVER['REQUEST_URI'] = '';
 	}
 
 	/**


### PR DESCRIPTION
In Views V2, in the `setup_the_loop` method, we set the `$_SERVER['REQUEST_URI']`;
this will mess up the permalinks parsing down the road for other tests.