### PR TITLE
Correctly set multi value meta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ services:
   - mysql
 
 before_install:
+  # Install version 1 of Composer.
+  - composer self-update --rollback
   - mysql -e 'CREATE DATABASE IF NOT EXISTS test;'
 
 install:

--- a/src/Mock/Builder/Event.php
+++ b/src/Mock/Builder/Event.php
@@ -312,7 +312,7 @@ class Event {
 	 */
 	protected function update_post_meta( $meta_key, $meta_value ) {
 		$all_meta              = get_post_meta( $this->event->ID );
-		$all_meta[ $meta_key ] = [ $meta_value ];
+		$all_meta[ $meta_key ] = (array) $meta_value;
 		wp_cache_set( $this->event->ID, $all_meta, 'post_meta' );
 	}
 


### PR DESCRIPTION
This small PR ensures that mock Events set up using the `with_organizers` method
will actually have the list of Organizer IDs correctly set up in the custom field
meta making sure the mock is correct.